### PR TITLE
Add gateway_user var + README.md improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ Using this code as example, it should be very easy to adapt it to any DBMS flavo
 
 ### Requirements
 
-- A bation (`gateway_host`) with access to database server (`target_host`) and its database administration port (`target_port`).  
+- A bation (`gateway_host`) with access to database server (`target_host`).
+
+- Check access from bastion (`gateway_host`) to database (`target_host:target_port`). Enable Security Group or firewall.
 
 - A SSH certificate recorded at the `~/.ssh/authorized_keys` of the remote user (`gateway_user`) at the bastion (`gateway_host`) to access without passphrase or password to remote host.  Also a passhprase protected certificate recorded to local ssh-agent may be used.
 
 - The command `timeout`. MacOS users need to install it with `brew install coreutils`.
 
-### Configuration
+### Configuration examples
 
 ```
 module db {
@@ -40,4 +42,31 @@ module db {
   }
 }
 ```
+
+```
+module pg {
+  source               = "git::git@github.com:flaupretre/terraform-ssh-tunnel-databases//postgresql"
+
+  target_host          = "your.remote.endpoint.rds.amazonaws.com"
+  target_port          = "5432"
+  gateway_host         = "IP.OF.YOUR.BASTION"
+  gateway_user         = "bastion-user"
+  username             = "rds-admin-user"
+  password             = "rds-admin-password"
+  db                   = {
+    "pgdatabase" = {
+      username    = "pgdatabase-user-rw"
+      password    = "a-password"
+      ro_username = "pgdatabase-user-ro"
+      ro_password = "a-password"
+    },
+     "otherdatabase" = {
+      username    = "otherdatabase-user-rw"
+      password    = "a-password"
+      ro_password = "a-password"
+    }
+  }
+}
+```
+
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,41 @@ The modules in this repository allow to create databases behind an SSH tunnel. T
 
 Using this code as example, it should be very easy to adapt it to any DBMS flavor.
 
+## Setup
+
+### Requirements
+
+- A bation (`gateway_host`) with access to database server (`target_host`) and its database administration port (`target_port`).  
+
+- A SSH certificate recorded at the `~/.ssh/authorized_keys` of the remote user (`gateway_user`) at the bastion (`gateway_host`) to access without passphrase or password to remote host.  Also a passhprase protected certificate recorded to local ssh-agent may be used.
+
+- The command `timeout`. MacOS users need to install it with `brew install coreutils`.
+
+### Configuration
+
+```
+module db {
+  source               = "git::git@github.com:flaupretre/terraform-ssh-tunnel-databases//mysql"
+
+  target_host          = "your.remote.endpoint.rds.amazonaws.com"
+  target_port          = "3306"
+  gateway_host         = "IP.OF.YOUR.BASTION"
+  gateway_user         = "bastion-user"
+  username             = "rds-admin-user"
+  password             = "rds-admin-password"
+  db                   = {
+    "mydatabase" = {
+      username    = "mydatabase-user-rw"
+      password    = "a-password"
+      ro_username = "mydatabase-user-ro"
+      ro_password = "a-password"
+    },
+     "anotherdatabase" = {
+      username    = "anotherdatabase-user-wd"
+      password    = "a-password"
+      ro_password = "a-password"
+    }
+  }
+}
+```
+

--- a/mysql/mysql.tf
+++ b/mysql/mysql.tf
@@ -9,6 +9,7 @@ module db_tunnel {
   target_host  = var.target_host
   target_port  = var.target_port
   gateway_host = var.gateway_host
+  gateway_user = var.gateway_user
 }
 
 #----

--- a/mysql/variables.tf
+++ b/mysql/variables.tf
@@ -3,6 +3,10 @@ variable gateway_host {
   type = string
 }
 
+variable gateway_user {
+  type = string
+}
+
 variable target_host {
   type = string
 }

--- a/postgresql/postgresql.tf
+++ b/postgresql/postgresql.tf
@@ -9,6 +9,7 @@ module db_tunnel {
   target_host  = var.target_host
   target_port  = var.target_port
   gateway_host = var.gateway_host
+  gateway_user = var.gateway_user
 }
 
 #----

--- a/postgresql/variables.tf
+++ b/postgresql/variables.tf
@@ -3,6 +3,10 @@ variable gateway_host {
   type = string
 }
 
+variable gateway_user {
+  type = string
+}
+
 variable target_host {
   type = string
 }


### PR DESCRIPTION
The README.md has copy/paste code to use the module and the list of required configuration.  I have also included `gateway_user` variable to module to simplify the ssh configuration.  The module has been check with Linux and MacOS